### PR TITLE
Add CIRCT Dockerfile

### DIFF
--- a/.github/workflows/circt.yml
+++ b/.github/workflows/circt.yml
@@ -1,0 +1,23 @@
+name: Build and push CIRCT docker image
+
+# Run on request and every day at 0300 PT
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 11 * * *
+
+jobs:
+  build-circt-image:
+    name: Build and push Docker image containing built CIRCT utilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get CIRCT images repo
+        uses: actions/checkout@v2
+      - name: Build and push image
+        working-directory: ./circt
+        run: |
+          sudo apt-get install -y jq
+          echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          hash=`curl -X GET https://api.github.com/repos/llvm/circt/commits/main | jq -r '.sha'`
+          docker build --build-arg circtHash=$hash -t ghcr.io/${{github.repository}}/circt:nightly .
+          docker push ghcr.io/${{github.repository}}/circt:nightly

--- a/circt/Dockerfile
+++ b/circt/Dockerfile
@@ -1,0 +1,27 @@
+FROM ghcr.io/circt/images/circt-integration-test:v3
+ARG circtHash
+
+# Checkout CIRCT and LLVM
+RUN git clone https://github.com/circt/circt.git /tmp/circt && \
+  cd /tmp/circt && \
+  git checkout $circtHash && \
+  git submodule update --init --depth 1
+
+# Build LLVM into llvm/build and llvm/build/install
+RUN cd /tmp/circt && ./utils/build-llvm.sh build build/install
+
+# Build CIRCT and install it in /usr
+RUN mkdir /tmp/circt/build && \
+  cd /tmp/circt/build && cmake -G Ninja .. \
+  -DMLIR_DIR=llvm/build/lib/cmake/mlir \
+  -DLLVM_DIR=llvm/build/lib/cmake/llvm \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DVERILATOR_PATH=/usr/bin/verilator \
+  -DCAPNP_PATH=/usr \
+  -DCMAKE_BUILD_TYPE=RELEASE \
+  -DCMAKE_INSTALL_PREFIX=/usr && \
+  ninja -j$(nproc) && \
+  ninja -j$(nproc) install
+
+# Cleanup to save space
+RUN rm -rf /tmp/circt

--- a/circt/README.md
+++ b/circt/README.md
@@ -1,0 +1,6 @@
+# CIRCT Utilities Container
+
+This container contains a built version of the [llvm/circt](https://github.com/llvm/circt) project.
+This can be used if you need a specific tool that CIRCT provides or want a base image for CI that provides CIRCT tools.
+
+Examples utilities are provided in the [`utils/`](utils) directory.

--- a/circt/build-latest-circt.sh
+++ b/circt/build-latest-circt.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Get the latest git hash using hte GitHub REST API
+hash=`curl -X GET https://api.github.com/repos/llvm/circt/commits/main | jq -r '.sha'`
+
+# Build the image
+docker build --build-arg circtHash=$hash -t ghcr.io/circt/images/circt:latest .

--- a/circt/utils/circt-opt
+++ b/circt/utils/circt-opt
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cmd="cd work && circt-opt $@"
+
+docker run -v $PWD:/work -i ghcr.io/circt/images/circt:nightly /bin/sh -c "$cmd"

--- a/circt/utils/circt-translate
+++ b/circt/utils/circt-translate
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cmd="cd work && circt-translate $@"
+
+docker run -v $PWD:/work -i ghcr.io/circt/images/circt:nightly /bin/sh -c "$cmd"

--- a/circt/utils/firtool
+++ b/circt/utils/firtool
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cmd="cd work && firtool $@"
+
+docker run -v $PWD:/work -i ghcr.io/circt/images/circt:nightly /bin/sh -c "$cmd"


### PR DESCRIPTION
Adds a Dockerfile for an image consisting of an installation of
llvm/circt off the 'main' branch (whatever it pulls when the
Dockerfile runs). This provides a lean-ish (~500MB) install of
circt-opt, circt-translate, and firtool that can either be wrapped in
a shell script to fake an install of these tools or can be used as a
base image.

Adds nightly publishing of this CIRCT image.

@teqdruid: I'm not sure where this should live. E.g., should this be in llvm/circt proper?

This is trying to solve the issue of I'm developing a dependent project that needs to have access to the binary tools that llvm/circt provides. I obviously don't want to build this in CI myself and cache it, so I created this. (I also don't think such a thing already exists?)