### PR TITLE
Add Quartus to integration tests

### DIFF
--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -10,11 +10,20 @@ RUN apt-get update && apt-get install -y \
   build-essential cmake make ninja-build pkg-config \
   autoconf bc bison flex libfl2 libfl-dev perl libssl-dev \
   python3 python3-pip \
-  git yosys
+  git yosys \
+  libncurses5
+
+# Specifically for ModelSimAE
+RUN dpkg --add-architecture i386
+RUN apt-get update
+RUN apt-get install -y libxext6:i386 libxft2:i386
 
 RUN python3 -m pip install pycapnp psutil
 
 COPY *.sh /tmp/
+
+# Download, install, then cleanup Quartus/ModelSimAE
+RUN /tmp/quartus.sh
 
 # Compile, install, then cleanup Cap'nProto
 RUN /tmp/capnp.sh
@@ -23,3 +32,5 @@ RUN rm -r /tmp/capnp
 # Compile, install, then cleanup Verilator
 RUN /tmp/verilator.sh
 RUN rm -r /tmp/verilator-*
+
+ENV PATH="/usr/local/intelFPGA_pro/20.4/quartus/bin:/usr/local/intelFPGA_pro/20.4/modelsim_ase/bin:${PATH}"

--- a/integration_test/quartus.sh
+++ b/integration_test/quartus.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Downloads and installs Quartus and ModelSimAE into $/ext
+# Includes the license file free device libraries and the
+# license file free, restricted functionality ModelSim/Questa
+
+cd /tmp
+mkdir intel
+cd intel
+
+wget https://download.altera.com/akdlm/software/acdsinst/20.4/72/ib_tar/Quartus-pro-20.4.0.72-linux.tar
+wget https://download.altera.com/akdlm/software/acdsinst/20.4/72/ib_tar/Quartus-pro-20.4.0.72-devices-3.tar
+
+tar -xf Quartus-pro-20.4.0.72-linux.tar
+tar -xf Quartus-pro-20.4.0.72-devices-3.tar
+
+./setup_pro.sh --mode unattended --installdir /usr/local/intelFPGA_pro/20.4 --accept_eula 1 --disable-components quartus_help,devinfo,quartus_update,modelsim_ae
+
+#Allowed: quartus quartus_help devinfo arria_lite cyclone cyclone10lp cyclonev max max10 quartus_update modelsim_ase modelsim_ae
+
+cd /tmp
+rm -r intel
+


### PR DESCRIPTION
Add Quartus and the license-file-not-needed device family.  Also get modelsim_ase, the crippled questa version (but should be enough for parsing/linting).