### PR TITLE
Bump circt/images base image to integration v5

### DIFF
--- a/circt/Dockerfile
+++ b/circt/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/circt/images/circt-integration-test:v3
+FROM ghcr.io/circt/images/circt-integration-test:v5
 ARG circtHash
 
 # Checkout CIRCT and LLVM


### PR DESCRIPTION
We've been failing on the nightly builds for a while due to my change in the required verilator version. Switching the base dockerfile to use the v5 of integration should fix this.