### PR TITLE
Use the latest release of llvm and clang

### DIFF
--- a/circt-ci-build/Dockerfile
+++ b/circt-ci-build/Dockerfile
@@ -6,18 +6,28 @@ RUN apt-get update && apt-get install apt-utils -y
 RUN apt-get upgrade -y
 RUN apt-get update && apt-get install -y \
   man curl wget unzip tar ca-certificates libtool \
-  clang lld \
   build-essential cmake make ninja-build pkg-config \
   autoconf bc bison flex libfl2 libfl-dev perl libssl-dev \
-  python3 python3-pip \
-  clang-tidy-9
+  python3 python3-pip
 
-RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy \
-        /usr/bin/clang-tidy-9 100
 RUN pip3 install yapf
 
 RUN apt-get install -y zlib1g-dev libcurl4-openssl-dev tcl8.6-dev \
   gettext
+
+# Install latest release of LLVM
+RUN wget https://apt.llvm.org/llvm.sh; \
+    chmod +x llvm.sh; \
+    ./llvm.sh 12;\
+    apt install -y clang-format-12 clang-tidy-12
+
+RUN ln -s /usr/bin/clang-12 /usr/bin/clang;\
+    ln -s /usr/bin/clang++-12 /usr/bin/clang++;\
+    ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy;\
+    ln -s /usr/bin/clang-tidy-diff-12.py /usr/bin/clang-tidy-diff;\
+    ln -s /usr/bin/clang-format-12 /usr/bin/clang-format;\
+    ln -s /usr/bin/clang-format-diff-12 /usr/bin/clang-format-diff;\
+    ln -s /usr/bin/lld-12 /usr/bin/lld
 
 # Ubuntu 18.04 only has git 2.17. GitHub needs git version >2.18.
 RUN wget https://github.com/git/git/archive/v2.23.0.tar.gz -O /root/git.tar.gz

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get install apt-utils -y
 RUN apt-get upgrade -y
 RUN apt-get update && apt-get install -y \
   man curl wget unzip tar ca-certificates libtool \
-  clang lld \
   build-essential ccache cmake make ninja-build pkg-config \
   autoconf bc bison flex libfl2 libfl-dev perl libssl-dev \
   git yosys
@@ -16,6 +15,20 @@ RUN apt-get update && apt-get install -y \
 
 RUN python3.8 -m pip install pycapnp psutil pybind11==2.6.2 numpy
 RUN python3.9 -m pip install pycapnp psutil pybind11==2.6.2 numpy
+
+# Install latest release of LLVM
+RUN wget https://apt.llvm.org/llvm.sh; \
+    chmod +x llvm.sh; \
+    ./llvm.sh 12;\
+    apt install -y clang-format-12 clang-tidy-12
+
+RUN ln -s /usr/bin/clang-12 /usr/bin/clang;\
+    ln -s /usr/bin/clang++-12 /usr/bin/clang++;\
+    ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy;\
+    ln -s /usr/bin/clang-tidy-diff-12.py /usr/bin/clang-tidy-diff;\
+    ln -s /usr/bin/clang-format-12 /usr/bin/clang-format;\
+    ln -s /usr/bin/clang-format-diff-12 /usr/bin/clang-format-diff;\
+    ln -s /usr/bin/lld-12 /usr/bin/lld
 
 COPY *.sh /tmp/
 


### PR DESCRIPTION
This copies the llvm builder bot docker file and installs LLVM using a
helper script hosted at llvm.org. This fixes several problems we have
had with different versions of clang-format disagreeing.