### PR TITLE
Link the git-clang-format-12 command to git-clang-format

### DIFF
--- a/circt-ci-build/Dockerfile
+++ b/circt-ci-build/Dockerfile
@@ -25,4 +25,5 @@ RUN ln -s /usr/bin/clang-12 /usr/bin/clang;\
     ln -s /usr/bin/clang-tidy-diff-12.py /usr/bin/clang-tidy-diff;\
     ln -s /usr/bin/clang-format-12 /usr/bin/clang-format;\
     ln -s /usr/bin/clang-format-diff-12 /usr/bin/clang-format-diff;\
+    ln -s /usr/bin/git-clang-format-12 /usr/bin/git-clang-format;\
     ln -s /usr/bin/lld-12 /usr/bin/lld

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -29,6 +29,7 @@ RUN ln -s /usr/bin/clang-12 /usr/bin/clang;\
     ln -s /usr/bin/clang-tidy-diff-12.py /usr/bin/clang-tidy-diff;\
     ln -s /usr/bin/clang-format-12 /usr/bin/clang-format;\
     ln -s /usr/bin/clang-format-diff-12 /usr/bin/clang-format-diff;\
+    ln -s /usr/bin/git-clang-format-12 /usr/bin/git-clang-format;\
     ln -s /usr/bin/lld-12 /usr/bin/lld
 
 COPY *.sh /tmp/


### PR DESCRIPTION
`git clang-format` is used by CIRCT CI to check the formatting on pull requests.  Although it is not technically needed for the integration image, keeping these blocks of code the same keeps it simple.