### PR TITLE
Add OR-Tools to integration_test image.

### DIFF
--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -42,6 +42,10 @@ RUN rm -r /tmp/capnp
 RUN /tmp/verilator.sh
 RUN rm -r /tmp/verilator-*
 
+# Compile, install, then cleanup OR-Tools
+RUN /tmp/or-tools.sh
+RUN rm -r /tmp/or-tools-*
+
 # Create manylinux compatible directory structure.
 RUN mkdir -p /opt/python/cp38-cp38/bin; \
     ln -s /usr/bin/python3.8 /opt/python/cp38-cp38/bin/python; \

--- a/integration_test/or-tools.sh
+++ b/integration_test/or-tools.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Downloads, compiles, and installs OR-Tools into /usr
+
+OR_TOOLS_VER=9.1
+
+# Disable fetching and building SCIP because of its license:
+#  "SCIP is distributed under the ZIB Academic License. You are allowed to
+#   retrieve SCIP for research purposes as a member of a non-commercial or
+#   academic institution."
+export USE_SCIP=OFF
+
+cd /tmp
+wget https://github.com/google/or-tools/archive/v$OR_TOOLS_VER.tar.gz
+tar -zxf v$OR_TOOLS_VER.tar.gz
+rm v$OR_TOOLS_VER.tar.gz
+cd or-tools-$OR_TOOLS_VER
+make -j$(nproc) third_party
+make -j$(nproc) cc
+make install_cc prefix=/usr

--- a/integration_test/or-tools.sh
+++ b/integration_test/or-tools.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 # Downloads, compiles, and installs OR-Tools into /usr
 
-OR_TOOLS_VER=9.1
+OR_TOOLS_VER=9.2
 
-# Disable fetching and building SCIP because of its license:
+# Disable fetching and building SCIP below because of its license:
 #  "SCIP is distributed under the ZIB Academic License. You are allowed to
 #   retrieve SCIP for research purposes as a member of a non-commercial or
 #   academic institution."
-export USE_SCIP=OFF
 
 cd /tmp
 wget https://github.com/google/or-tools/archive/v$OR_TOOLS_VER.tar.gz
 tar -zxf v$OR_TOOLS_VER.tar.gz
 rm v$OR_TOOLS_VER.tar.gz
 cd or-tools-$OR_TOOLS_VER
-make -j$(nproc) third_party
-make -j$(nproc) cc
-make install_cc prefix=/usr
+cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_SAMPLES=OFF -DBUILD_EXAMPLES=OFF -DBUILD_FLATZINC=OFF -DUSE_SCIP=OFF
+cmake --build build --parallel $(nproc)
+cmake --install build --prefix /usr


### PR DESCRIPTION
Google's [OR-Tools](https://developers.google.com/optimization) provide an interface to a variety of open-source and commercial solvers for (I)LP, SAT, etc., which I'd like to *optionally* use in CIRCT Scheduling in the future.

I'll leave this as a draft for now (until there's actual code requiring the libraries), but please let me know if there are any concerns about adding this to the integration_test image.