### PR TITLE
Symlink lld to the path expected by gcc.

### DIFF
--- a/circt-ci-build/Dockerfile
+++ b/circt-ci-build/Dockerfile
@@ -26,4 +26,5 @@ RUN ln -s /usr/bin/clang-13 /usr/bin/clang;\
     ln -s /usr/bin/clang-format-13 /usr/bin/clang-format;\
     ln -s /usr/bin/clang-format-diff-13 /usr/bin/clang-format-diff;\
     ln -s /usr/bin/git-clang-format-13 /usr/bin/git-clang-format;\
-    ln -s /usr/bin/lld-13 /usr/bin/lld
+    ln -s /usr/bin/lld-13 /usr/bin/lld;\
+    ln -s /usr/bin/lld-13 /usr/bin/ld.lld

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -30,7 +30,8 @@ RUN ln -s /usr/bin/clang-13 /usr/bin/clang;\
     ln -s /usr/bin/clang-format-13 /usr/bin/clang-format;\
     ln -s /usr/bin/clang-format-diff-13 /usr/bin/clang-format-diff;\
     ln -s /usr/bin/git-clang-format-13 /usr/bin/git-clang-format;\
-    ln -s /usr/bin/lld-13 /usr/bin/lld
+    ln -s /usr/bin/lld-13 /usr/bin/lld;\
+    ln -s /usr/bin/lld-13 /usr/bin/ld.lld
 
 COPY *.sh /tmp/
 


### PR DESCRIPTION
When given `-fuse-ld=lld`, gcc [seems](https://stackoverflow.com/a/64174822) to only look for executables named `ld.lld`. Such a thing was provided by the [lld package](https://packages.ubuntu.com/en/focal/amd64/lld/filelist), but was missing in the custom LLVM install.

This fixes https://github.com/llvm/circt/issues/2479.