### PR TITLE
Bump OR-Tools version.

### DIFF
--- a/integration_test/or-tools.sh
+++ b/integration_test/or-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Downloads, compiles, and installs OR-Tools into /usr
 
-OR_TOOLS_VER=9.2
+OR_TOOLS_VER=9.5
 
 # Disable fetching and building SCIP below because of its license:
 #  "SCIP is distributed under the ZIB Academic License. You are allowed to


### PR DESCRIPTION
Simple version bump to keep things up-to-date. The SCIP solver was recently re-licensed under Apache 2.0, however, the version OR-Tools pulls in is unfortunately still subject to the old license, so no changes there.

I tested building the image locally. No changes are required to CIRCT.