### PR TITLE
Update clang to 17 in short integration test image

### DIFF
--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -19,21 +19,21 @@ RUN python3.9 -m pip install pycapnp psutil pybind11==2.9.1 numpy jinja2 cocotb 
 
 RUN apt-get update && apt-get install -y tcl
 
-# Install latest release of LLVM
+# Install a more recent release of LLVM
 RUN wget https://apt.llvm.org/llvm.sh; \
   chmod +x llvm.sh; \
-  ./llvm.sh 16;\
-  apt install -y clang-format-16 clang-tidy-16
+  ./llvm.sh 17;\
+  apt install -y clang-format-17 clang-tidy-17
 
-RUN ln -s /usr/bin/clang-16 /usr/bin/clang;\
-  ln -s /usr/bin/clang++-16 /usr/bin/clang++;\
-  ln -s /usr/bin/clang-tidy-16 /usr/bin/clang-tidy;\
-  ln -s /usr/bin/clang-tidy-diff-16.py /usr/bin/clang-tidy-diff;\
-  ln -s /usr/bin/clang-format-16 /usr/bin/clang-format;\
-  ln -s /usr/bin/clang-format-diff-16 /usr/bin/clang-format-diff;\
-  ln -s /usr/bin/git-clang-format-16 /usr/bin/git-clang-format;\
-  ln -s /usr/bin/lld-16 /usr/bin/lld;\
-  ln -s /usr/bin/lld-16 /usr/bin/ld.lld
+RUN ln -s /usr/bin/clang-17 /usr/bin/clang; \
+  ln -s /usr/bin/clang++-17 /usr/bin/clang++; \
+  ln -s /usr/bin/clang-tidy-17 /usr/bin/clang-tidy; \
+  ln -s /usr/bin/clang-tidy-diff-17.py /usr/bin/clang-tidy-diff; \
+  ln -s /usr/bin/clang-format-17 /usr/bin/clang-format; \
+  ln -s /usr/bin/clang-format-diff-17 /usr/bin/clang-format-diff; \
+  ln -s /usr/bin/git-clang-format-17 /usr/bin/git-clang-format; \
+  ln -s /usr/bin/lld-17 /usr/bin/lld; \
+  ln -s /usr/bin/lld-17 /usr/bin/ld.lld
 
 # Install GCC 11 to get C++20 header support and support for building slang
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Updating `slang` requires `C++20`. Compiling with `C++20` fails with `clang-16` due to operator ambiguity errors.