### PR TITLE
Install psutil to circt-ci-build

### DIFF
--- a/circt-ci-build/Dockerfile
+++ b/circt-ci-build/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
   python3 python3-pip valgrind
 
 RUN python3 -m pip config set global.break-system-packages true
-RUN pip3 install yapf toml GitPython
+RUN pip3 install yapf toml GitPython psutil
 
 # Install a more recent release of LLVM
 RUN wget https://apt.llvm.org/llvm.sh; \


### PR DESCRIPTION
psutil is required to set time limit on llvm-lit. It's already installed other than circt-ci-build. 