### PR TITLE
Bump clang to 21

### DIFF
--- a/circt-ci-build/Dockerfile
+++ b/circt-ci-build/Dockerfile
@@ -15,20 +15,21 @@ RUN python3 -m pip config set global.break-system-packages true
 RUN pip3 install yapf toml GitPython psutil
 
 # Install a more recent release of LLVM
-RUN wget https://apt.llvm.org/llvm.sh; \
-  chmod +x llvm.sh; \
-  ./llvm.sh 17;\
-  apt install -y clang-format-17 clang-tidy-17
+RUN wget https://apt.llvm.org/llvm.sh \
+  && chmod +x llvm.sh \
+  && ./llvm.sh 21 \
+  && apt-get update \
+  && apt install -y clang-format-21 clang-tidy-21
 
-RUN ln -s /usr/bin/clang-17 /usr/bin/clang; \
-  ln -s /usr/bin/clang++-17 /usr/bin/clang++; \
-  ln -s /usr/bin/clang-tidy-17 /usr/bin/clang-tidy; \
-  ln -s /usr/bin/clang-tidy-diff-17.py /usr/bin/clang-tidy-diff; \
-  ln -s /usr/bin/clang-format-17 /usr/bin/clang-format; \
-  ln -s /usr/bin/clang-format-diff-17 /usr/bin/clang-format-diff; \
-  ln -s /usr/bin/git-clang-format-17 /usr/bin/git-clang-format; \
-  ln -s /usr/bin/lld-17 /usr/bin/lld; \
-  ln -s /usr/bin/lld-17 /usr/bin/ld.lld
+RUN ln -s /usr/bin/clang-21 /usr/bin/clang; \
+  ln -s /usr/bin/clang++-21 /usr/bin/clang++; \
+  ln -s /usr/bin/clang-tidy-21 /usr/bin/clang-tidy; \
+  ln -s /usr/bin/clang-tidy-diff-21.py /usr/bin/clang-tidy-diff; \
+  ln -s /usr/bin/clang-format-21 /usr/bin/clang-format; \
+  ln -s /usr/bin/clang-format-diff-21 /usr/bin/clang-format-diff; \
+  ln -s /usr/bin/git-clang-format-21 /usr/bin/git-clang-format; \
+  ln -s /usr/bin/lld-21 /usr/bin/lld; \
+  ln -s /usr/bin/lld-21 /usr/bin/ld.lld
 
 # Install GCC 11 to get C++20 header support and support for building slang
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/integration-test.dockerfile
+++ b/integration-test.dockerfile
@@ -49,20 +49,21 @@ RUN python3.12 -m pip install pycapnp psutil pybind11==2.11.2 nanobind==2.9.2 nu
 RUN apt-get update && apt-get install -y tcl
 
 # Install a more recent release of LLVM
-RUN wget https://apt.llvm.org/llvm.sh; \
-  chmod +x llvm.sh; \
-  ./llvm.sh 17;\
-  apt install -y clang-format-17 clang-tidy-17
+RUN wget https://apt.llvm.org/llvm.sh \
+  && chmod +x llvm.sh \
+  && ./llvm.sh 21 \
+  && apt-get update \
+  && apt install -y clang-format-21 clang-tidy-21
 
-RUN ln -s /usr/bin/clang-17 /usr/bin/clang; \
-  ln -s /usr/bin/clang++-17 /usr/bin/clang++; \
-  ln -s /usr/bin/clang-tidy-17 /usr/bin/clang-tidy; \
-  ln -s /usr/bin/clang-tidy-diff-17.py /usr/bin/clang-tidy-diff; \
-  ln -s /usr/bin/clang-format-17 /usr/bin/clang-format; \
-  ln -s /usr/bin/clang-format-diff-17 /usr/bin/clang-format-diff; \
-  ln -s /usr/bin/git-clang-format-17 /usr/bin/git-clang-format; \
-  ln -s /usr/bin/lld-17 /usr/bin/lld; \
-  ln -s /usr/bin/lld-17 /usr/bin/ld.lld
+RUN ln -s /usr/bin/clang-21 /usr/bin/clang; \
+  ln -s /usr/bin/clang++-21 /usr/bin/clang++; \
+  ln -s /usr/bin/clang-tidy-21 /usr/bin/clang-tidy; \
+  ln -s /usr/bin/clang-tidy-diff-21.py /usr/bin/clang-tidy-diff; \
+  ln -s /usr/bin/clang-format-21 /usr/bin/clang-format; \
+  ln -s /usr/bin/clang-format-diff-21 /usr/bin/clang-format-diff; \
+  ln -s /usr/bin/git-clang-format-21 /usr/bin/git-clang-format; \
+  ln -s /usr/bin/lld-21 /usr/bin/lld; \
+  ln -s /usr/bin/lld-21 /usr/bin/ld.lld
 
 # Install GCC 11 to get C++20 header support and support for building slang
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Bump clang from 17 to 21.  There have been valgrind build failures in nightly with Clang 17 [[1]] that I was unable to reproduce with newer Clang.  This empirically gets nightly to pass valgrind tests that were previously failing.

This requires an additional flag to disable pre-compiled headers (PCH):

    -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON

[1]: https://github.com/llvm/circt/issues/9914

Here is the output from running this in the container:

``` console
root@b28ee7819de1:/circt/build# clang --version
Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-21/bin
root@b28ee7819de1:/circt/build# ./bin/llvm-lit -v --vg ../test/arcilator/arcilator.mlir ../test/arcilator/compreg.mlir
-- Testing: 2 tests, 2 workers --
PASS: CIRCT :: arcilator/compreg.mlir (1 of 2)
PASS: CIRCT :: arcilator/arcilator.mlir (2 of 2)

Testing Time: 6.60s

Total Discovered Tests: 2
  Passed: 2 (100.00%)
```