### PR TITLE
Bump cmake to 3.28.4

### DIFF
--- a/circt-ci-build/Dockerfile
+++ b/circt-ci-build/Dockerfile
@@ -35,5 +35,5 @@ RUN ln -s /usr/bin/clang-21 /usr/bin/clang; \
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt install -y g++-11
 
-ADD https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.sh /tmp/cmake_install.sh
+ADD https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.sh /tmp/cmake_install.sh
 RUN bash /tmp/cmake_install.sh --prefix=/usr/local --skip-license

--- a/circt-windows/Dockerfile
+++ b/circt-windows/Dockerfile
@@ -59,7 +59,7 @@ RUN C:\TEMP\python37-install.exe /quiet InstallAllUsers=1 PrependPath=1 Include_
 RUN ("C:\Program Files\Python37\python.exe" -m pip install wheel numpy pyyaml pybind11 nanobind==2.9.2 cocotb~=1.9 cocotb-test~=0.2 jinja2 psutil)
 
 # Get latest version of cmake
-ADD https://github.com/Kitware/CMake/releases/download/v3.26.0/cmake-3.26.0-windows-x86_64.msi C:\TEMP\cmake.msi
+ADD https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-windows-x86_64.msi C:\TEMP\cmake.msi
 RUN msiexec /i C:\TEMP\cmake.msi
 
 # Install PowerShell

--- a/install/cmake.sh
+++ b/install/cmake.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-CMAKE_VER=3.23.2
+CMAKE_VER=3.28.4
 
 # Detect the host's architecture to download the appropriate release.
 case $(uname -m) in


### PR DESCRIPTION
The cmake versions installed in our images were too old. Bump all pinned versions to 3.28.4 across the Linux install script and the CI build and Windows Dockerfiles.